### PR TITLE
fix: llegalArgumentException: host = null

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,7 +18,7 @@ version="1.3.1" #mandatory
  # A display name for the mod
 displayName="Traveller's Boots" #mandatory
 # A URL to query for updates for this mod. See the JSON update specification <here>
-updateJSONURL="http:/myurl.me/" #optional
+updateJSONURL="http://myurl.me/" #optional
 # A URL for the "homepage" for this mod, displayed in the mod UI
 displayURL="" #optional
 # A file name (in the root of the mod JAR) containing a logo for display


### PR DESCRIPTION
Should fix warning with:
```text/plain
 [Forge Version Check/WARN] [ne.mi.fm.VersionChecker/]: Failed to process update information
java.lang.RuntimeException: java.lang.IllegalArgumentException: protocol = http host = null
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1512) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1498) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.getHeaderField(HttpURLConnection.java:3097) ~[?:1.8.0_232]
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:489) ~[?:1.8.0_232]
	at net.minecraftforge.fml.VersionChecker$1.openUrlStream(VersionChecker.java:173) ~[?:?]
	at net.minecraftforge.fml.VersionChecker$1.process(VersionChecker.java:206) ~[?:?]
	at java.lang.Iterable.forEach(Iterable.java:75) [?:1.8.0_232]
	at net.minecraftforge.fml.VersionChecker$1.run(VersionChecker.java:157) [?:?]
Caused by: java.lang.IllegalArgumentException: protocol = http host = null
	at sun.net.spi.DefaultProxySelector.select(DefaultProxySelector.java:177) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1156) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:990) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1570) ~[?:1.8.0_232]
	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1498) ~[?:1.8.0_232]
	at java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:480) ~[?:1.8.0_232]
```